### PR TITLE
175399861_add_better_handling_404

### DIFF
--- a/app/assets/stylesheets/not_found.scss
+++ b/app/assets/stylesheets/not_found.scss
@@ -1,0 +1,24 @@
+.error-body {
+  color: #0b254b;
+  text-align: center;
+  font-family: arial, sans-serif;
+  margin: 0;
+  font-size: 19px;
+}
+
+.background {
+  background-image: linear-gradient(#fff 0%, #edf4ff 100%);
+  border-bottom-left-radius: 50% 100px;
+  border-bottom-right-radius: 50% 100px;
+  padding: 20vh 25px 15vh 25px;
+}
+
+.content {
+  width: 100%;
+  max-width: 1140px;
+  margin: auto
+}
+
+.not-found-message {
+  margin-bottom: 30px;
+}

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -41,6 +41,10 @@ class PublicController < ApplicationController
     @title = t('public.contact_us.title')
   end
 
+  def not_found
+    render :not_found, status: :not_found, layout: 'error_page'
+  end
+
   private
   def contact_us_params
     params.require(:contact_request)

--- a/app/views/layouts/error_page.html.erb
+++ b/app/views/layouts/error_page.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= t('site_title') %></title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+          crossorigin="anonymous">
+    <!-- Bootstrap JS -->
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+            integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+            crossorigin="anonymous">
+    </script>
+    <!-- Font Awesome -->
+    <script src="https://kit.fontawesome.com/<%= Rails.application.credentials.dig(:font_awesome_download_key)%>.js"
+            crossorigin="anonymous">
+    </script>
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/public/not_found.en.html.erb
+++ b/app/views/public/not_found.en.html.erb
@@ -1,0 +1,13 @@
+<div class="error-body">
+  <div class="background">
+    <div class="content">
+      <h1><%= t('public.not_found.heading') %></h1>
+      <p class="not-found-message">
+        <%= t('public.not_found.not_found_message') %><%= link_to "Home page", root_path %>
+      </p>
+      <%= link_to root_path do %>
+        <%= image_tag("https://www-movingleads-com-production.s3.amazonaws.com/fmadata-logo_1.png") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/not_found.pl.html.erb
+++ b/app/views/public/not_found.pl.html.erb
@@ -1,0 +1,13 @@
+<div class="error-body">
+  <div class="background">
+    <div class="content">
+      <h1><%= t('public.not_found.heading') %></h1>
+      <p class="not-found-message">
+        <%= t('public.not_found.not_found_message') %><%= link_to "Home page", root_path %>
+      </p>
+      <%= link_to root_path do %>
+        <%= image_tag("https://www-movingleads-com-production.s3.amazonaws.com/fmadata-logo_1.png") %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,9 @@ en:
           telephone: 'Telephone'
           comments: 'Message'
           created_at: 'Created at'
+    not_found:
+      heading: "The page you're looking for does not exist."
+      not_found_message: "Sorry, not this time... You may have mistyped the address or the page may have moved. Go to the "
   site_title: "FMA Ruby On Rails Template"
   error:
     one: '%{count} error'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -64,6 +64,9 @@ pl:
           telephone: 'Telefon'
           comments: 'Wiadomość'
           created_at: 'Dodano'
+    not_found:
+      heading: "Strona, której szukasz nie istnieje."
+      not_found_message: "Wybacz, nie tym razem... W adresie strony znajduje się błąd lub strona została przeniesiona. Idź do "
   site_title: "FMA Ruby On Rails Szablon"
   error:
     one: '%{count} błąd'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,6 @@ Rails.application.routes.draw do
 
   # Default root path
   root to: 'public#index'
+
+  match '*path', via: :all, to: 'public#not_found'
 end

--- a/test/controllers/public_controller_test.rb
+++ b/test/controllers/public_controller_test.rb
@@ -9,7 +9,6 @@ class PublicControllerTest < ActionDispatch::IntegrationTest
         telephone: '123456789'
       }
     }
-
     @admin_one = create(:user, :admin)
   end
 
@@ -102,5 +101,12 @@ class PublicControllerTest < ActionDispatch::IntegrationTest
     assert_difference('ActionMailer::Base.deliveries.count') do
       post contact_us_url, params: @contact_us_params
     end
+  end
+
+  test "wrong path renders not_found" do
+    heading = "<h1>The page you&#39;re looking for does not exist.</h1>\n"
+    get '/i_do_not_exist'
+    assert_response 404
+    assert_includes response.body, heading
   end
 end


### PR DESCRIPTION
#### What's this PR do?
- Add not_found page with css and test 

#### How should this be manually tested?
- Run rails s
- Go to the non existing path
- Check the server logs, you should see something like that:

```
Started GET "/asd" for 127.0.0.1 at 2020-10-28 13:35:45 +0100
   (0.6ms)  SET NAMES utf8,  @@SESSION.sql_mode = CONCAT(CONCAT(@@sql_mode, ',STRICT_ALL_TABLES'), ',NO_AUTO_VALUE_ON_ZERO'),  @@SESSION.sql_auto_is_null = 0, @@SESSION.wait_timeout = 2147483
Processing by PublicController#not_found as HTML
  Parameters: {"path"=>"asd"}
  Rendering public/not_found.en.html.erb within layouts/error_page
  Rendered public/not_found.en.html.erb within layouts/error_page (Duration: 0.7ms | Allocations: 172)
[Webpacker] Everything's up-to-date. Nothing to do
Completed 404 Not Found in 8ms (Views: 6.2ms | ActiveRecord: 0.0ms | Allocations: 3784)
```
#### What are the relevant tickets?
- https://www.pivotaltracker.com/story/show/175399861

#### Task completed checklist:
- [x] Is there appropriate test coverage?
- [x] Did I take into consideration possible security vulnerabilities?
- [x] Are the controllers secure?
- [x] Was every important matter documented?

#### Things to watch out for
- [N] Does this PR have any migrations?
- [N] Does this PR add new dependencies?
